### PR TITLE
barrier for chain

### DIFF
--- a/test/vizcircuit.jl
+++ b/test/vizcircuit.jl
@@ -79,3 +79,14 @@ end
 @testset "regression" begin
 	@test vizcircuit(put(10, (8,2,3)=>EasyBuild.heisenberg(3)), starting_texts=string.(1:10), ending_texts=string.(1:10), show_ending_bar=true) isa Drawing
 end
+
+@testset "readme" begin
+    circuit = chain(
+        4,    
+        kron(X, H, H, H),
+        kron(1=>Y, 4=>H), 
+        put(2=>Y),
+    )
+    YaoPlots.CircuitStyles.barrier_for_chain[] = true
+    @test vizcircuit(circuit) isa Drawing
+end


### PR DESCRIPTION
Add a new global constant for toggling barrier and compact mode.

## The `compact` mode (default)
```julia
julia> using Yao, YaoPlots

julia> circuit = chain(
           4,    
           kron(X, H, H, H),
           kron(1=>Y, 4=>H), 
           put(2=>Y),
       );

julia> YaoPlots.CircuitStyles.barrier_for_chain[] = false; vizcircuit(circuit)
```
![image](https://user-images.githubusercontent.com/6257240/196037053-798f92dc-5d46-4121-bcd2-854fe3f1275f.png)

## The `barrier` mode
```julia
julia> YaoPlots.CircuitStyles.barrier_for_chain[] = true; vizcircuit(circuit)
```

![image](https://user-images.githubusercontent.com/6257240/196037152-41c3aad8-c7d9-4939-b659-b6f1b4bb33be.png)
